### PR TITLE
Updated signup.html and style + added a signup javascript

### DIFF
--- a/src/PublicResources/CSS/Frontendstyle.css
+++ b/src/PublicResources/CSS/Frontendstyle.css
@@ -233,9 +233,54 @@ button:hover,
 
 .day-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
-  gap: 12px;
+  grid-template-columns: minmax(0, 1fr);
   margin-top: 18px;
+}
+
+.day-selector {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 10px;
+  margin-top: 18px;
+}
+
+.day-selector__option {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 0;
+  padding: 8px 8px;
+  border: 1px solid #d7e0ef;
+  border-radius: 999px;
+  background: #ffffff;
+  color: #18476e;
+  font-weight: 600;
+  font-size: 14px;
+  line-height: 1.2;
+  white-space: nowrap;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.day-selector__option:hover {
+  background: #eef6ff;
+}
+
+.day-selector__option input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.day-selector__option input:checked + span {
+  color: #0f5c99;
+}
+
+.day-selector__option:has(input:checked) {
+  background: #e7f1fb;
+  border-color: #5b8fd9;
+  box-shadow: 0 0 0 3px rgba(91, 143, 217, 0.15);
 }
 
 .day-card {
@@ -331,5 +376,15 @@ button:hover,
 
   .button-row {
     flex-direction: column;
+  }
+
+  .day-selector {
+    gap: 6px;
+  }
+
+  .day-selector__option {
+    padding: 8px 6px;
+    font-size: clamp(11px, 2.8vw, 13px);
+    letter-spacing: -0.01em;
   }
 }

--- a/src/PublicResources/HTML/Signup.html
+++ b/src/PublicResources/HTML/Signup.html
@@ -8,7 +8,7 @@
 <body>
 <div class="Header">
     <div class="title">Sign Up</div>
-    <form action="signup-records" id="signupForm" method="post">
+    <form action="/users" id="signupForm" method="post">
         <fieldset>
             <div class="legend">Personal Information</div>
             <div class="user-details user-details--stacked">
@@ -29,8 +29,30 @@
 
         <fieldset>
             <div class="legend">Carpooling Preferences</div>
-            <div class="day-grid">
-                <section class="day-card" data-role-card>
+            <div class="day-selector" role="radiogroup" aria-label="Choose a day for carpooling preferences">
+                <label class="day-selector__option" for="signupDayMonday">
+                    <input type="radio" id="signupDayMonday" name="signupSelectedDay" value="monday" checked>
+                    <span>Monday</span>
+                </label>
+                <label class="day-selector__option" for="signupDayTuesday">
+                    <input type="radio" id="signupDayTuesday" name="signupSelectedDay" value="tuesday">
+                    <span>Tuesday</span>
+                </label>
+                <label class="day-selector__option" for="signupDayWednesday">
+                    <input type="radio" id="signupDayWednesday" name="signupSelectedDay" value="wednesday">
+                    <span>Wednesday</span>
+                </label>
+                <label class="day-selector__option" for="signupDayThursday">
+                    <input type="radio" id="signupDayThursday" name="signupSelectedDay" value="thursday">
+                    <span>Thursday</span>
+                </label>
+                <label class="day-selector__option" for="signupDayFriday">
+                    <input type="radio" id="signupDayFriday" name="signupSelectedDay" value="friday">
+                    <span>Friday</span>
+                </label>
+            </div>
+            <div class="day-grid" data-day-picker>
+                <section class="day-card" data-role-card data-day-card="monday">
                     <div class="day-card__title">Monday</div>
                     <div class="day-card__field">
                         <span class="details">Passenger or Driver</span>
@@ -49,7 +71,7 @@
                     </div>
                     <div class="day-card__field">
                         <label class="details" for="signupMondaySeats">Seats Available</label>
-                        <input type="number" id="signupMondaySeats" name="signupMondaySeatsOffered" min="0" max="8" placeholder="Auto 0 if passenger">
+                        <input type="number" id="signupMondaySeats" name="signupMondaySeatsOffered" min="0" max="5" placeholder="Number of seats including driver">
                     </div>
                     <div class="day-card__field">
                         <label class="details" for="signupMondayPickup">Pickup-point</label>
@@ -65,7 +87,7 @@
                     </div>
                 </section>
 
-                <section class="day-card" data-role-card>
+                <section class="day-card" data-role-card data-day-card="tuesday">
                     <div class="day-card__title">Tuesday</div>
                     <div class="day-card__field">
                         <span class="details">Passenger or Driver</span>
@@ -84,7 +106,7 @@
                     </div>
                     <div class="day-card__field">
                         <label class="details" for="signupTuesdaySeats">Seats Available</label>
-                        <input type="number" id="signupTuesdaySeats" name="signupTuesdaySeatsOffered" min="0" max="8" placeholder="Auto 0 if passenger">
+                        <input type="number" id="signupTuesdaySeats" name="signupTuesdaySeatsOffered" min="0" max="5" placeholder="Number of seats excluding driver">
                     </div>
                     <div class="day-card__field">
                         <label class="details" for="signupTuesdayPickup">Pickup-point</label>
@@ -100,7 +122,7 @@
                     </div>
                 </section>
 
-                <section class="day-card" data-role-card>
+                <section class="day-card" data-role-card data-day-card="wednesday">
                     <div class="day-card__title">Wednesday</div>
                     <div class="day-card__field">
                         <span class="details">Passenger or Driver</span>
@@ -119,7 +141,7 @@
                     </div>
                     <div class="day-card__field">
                         <label class="details" for="signupWednesdaySeats">Seats Available</label>
-                        <input type="number" id="signupWednesdaySeats" name="signupWednesdaySeatsOffered" min="0" max="8" placeholder="Auto 0 if passenger">
+                        <input type="number" id="signupWednesdaySeats" name="signupWednesdaySeatsOffered" min="0" max="5" placeholder="Number of seats excluding driver">
                     </div>
                     <div class="day-card__field">
                         <label class="details" for="signupWednesdayPickup">Pickup-point</label>
@@ -135,7 +157,7 @@
                     </div>
                 </section>
 
-                <section class="day-card" data-role-card>
+                <section class="day-card" data-role-card data-day-card="thursday">
                     <div class="day-card__title">Thursday</div>
                     <div class="day-card__field">
                         <span class="details">Passenger or Driver</span>
@@ -154,7 +176,7 @@
                     </div>
                     <div class="day-card__field">
                         <label class="details" for="signupThursdaySeats">Seats Available</label>
-                        <input type="number" id="signupThursdaySeats" name="signupThursdaySeatsOffered" min="0" max="8" placeholder="Auto 0 if passenger">
+                        <input type="number" id="signupThursdaySeats" name="signupThursdaySeatsOffered" min="0" max="5" placeholder="Number of seats excluding driver">
                     </div>
                     <div class="day-card__field">
                         <label class="details" for="signupThursdayPickup">Pickup-point</label>
@@ -170,7 +192,7 @@
                     </div>
                 </section>
 
-                <section class="day-card" data-role-card>
+                <section class="day-card" data-role-card data-day-card="friday">
                     <div class="day-card__title">Friday</div>
                     <div class="day-card__field">
                         <span class="details">Passenger or Driver</span>
@@ -189,7 +211,7 @@
                     </div>
                     <div class="day-card__field">
                         <label class="details" for="signupFridaySeats">Seats Available</label>
-                        <input type="number" id="signupFridaySeats" name="signupFridaySeatsOffered" min="0" max="8" placeholder="Auto 0 if passenger">
+                        <input type="number" id="signupFridaySeats" name="signupFridaySeatsOffered" min="0" max="5" placeholder="Number of seats excluding driver">
                     </div>
                     <div class="day-card__field">
                         <label class="details" for="signupFridayPickup">Pickup-point</label>
@@ -208,33 +230,9 @@
         </fieldset>
 
         <button id="signupSubmit" type="submit">Sign Up</button>
-        <p class="login-text">Already have an account? <a href="https://media.newyorker.com/photos/59095bb86552fa0be682d9d0/master/pass/Monkey-Selfie.jpg">Login</a></p>
+        <p class="login-text">Already have an account? <a href="./Login.html">Login</a></p>
     </form>
 </div>
-<script>
-    document.querySelectorAll("[data-role-card]").forEach(function (card) {
-        var roleInputs = card.querySelectorAll('input[type="radio"]');
-        var availabilityInput = card.querySelector('input[name$="CarAvailability"]');
-        var intentInput = card.querySelector('input[name$="CarpoolingIntent"]');
-        var seatsInput = card.querySelector('input[name$="SeatsOffered"]');
-
-        function syncRole() {
-            var selected = card.querySelector('input[type="radio"]:checked');
-            var isDriver = selected && selected.value === "driver";
-            availabilityInput.value = isDriver ? "true" : "false";
-            intentInput.value = isDriver ? "true" : "false";
-
-            if (!isDriver) {
-                seatsInput.value = "0";
-            }
-        }
-
-        roleInputs.forEach(function (input) {
-            input.addEventListener("change", syncRole);
-        });
-
-        syncRole();
-    });
-</script>
+<script src="../JS/Signup.js"></script>
 </body>
 </html>

--- a/src/PublicResources/JS/Signup.js
+++ b/src/PublicResources/JS/Signup.js
@@ -1,0 +1,55 @@
+    document.querySelectorAll("[data-day-picker]").forEach(function (dayGrid) {
+        var dayInputs = dayGrid.parentElement.querySelectorAll('.day-selector input[type="radio"]');
+        var dayCards = dayGrid.querySelectorAll("[data-day-card]");
+        var selectedDay = "";
+
+        function syncDayCards() {
+            dayCards.forEach(function (card) {
+                var isSelected = card.dataset.dayCard === selectedDay;
+                card.hidden = !isSelected;
+            });
+        }
+
+        dayInputs.forEach(function (input) {
+            if (input.checked) {
+                selectedDay = input.value;
+            }
+
+            input.addEventListener("change", function () {
+                selectedDay = input.value;
+                syncDayCards();
+            });
+        });
+
+        if (!selectedDay && dayInputs.length > 0) {
+            selectedDay = dayInputs[0].value;
+            dayInputs[0].checked = true;
+        }
+
+        syncDayCards();
+    });
+
+    document.querySelectorAll("[data-role-card]").forEach(function (card) {
+        var roleInputs = card.querySelectorAll('input[type="radio"]');
+        var availabilityInput = card.querySelector('input[name$="CarAvailability"]');
+        var intentInput = card.querySelector('input[name$="CarpoolingIntent"]');
+        var seatsInput = card.querySelector('input[name$="SeatsOffered"]');
+
+        function syncRole() {
+            var selected = card.querySelector('input[type="radio"]:checked');
+            var isDriver = selected && selected.value === "driver";
+            availabilityInput.value = isDriver ? "true" : "false";
+            intentInput.value = isDriver ? "true" : "false";
+            seatsInput.disabled = !isDriver;
+
+            if (!isDriver) {
+                seatsInput.value = "0";
+            }
+        }
+
+        roleInputs.forEach(function (input) {
+            input.addEventListener("change", syncRole);
+        });
+
+        syncRole();
+    });


### PR DESCRIPTION
For the html part i changed signup-records to /users. Reworked the carpool day selection interface so users pick one weekday at a time with a radio-button.  Added data-day-card attributes to each weekday section so the selected day’s card can be shown/hidden dynamically.

For the script, i implemented logic to show only the currently selected weekday card. Set hidden availability/intent values based on driver vs passenger. Disable the seats field when the user is a passenger.

For the style, I changed day-grid from a multi-card grid to a single-column layout. Added styling to selected radio-buttons for weekdays. Added mobile tweaks for the new day selector.